### PR TITLE
TOOLS-1648 Move submodule reference to fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "diff-match-patch-cpp-stl"]
 	path = diff-match-patch-cpp-stl
-	url = https://github.com/leutloff/diff-match-patch-cpp-stl
+    url = https://github.com/razvan-pricop-ptt/diff-match-patch-cpp-stl

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "diff-match-patch-cpp-stl"]
 	path = diff-match-patch-cpp-stl
-    url = https://github.com/razvan-pricop-ptt/diff-match-patch-cpp-stl
+	url = https://github.com/pentesttoolscom/diff-match-patch-cpp-stl

--- a/gen_test.py
+++ b/gen_test.py
@@ -1,0 +1,243 @@
+import json
+import random
+import string
+import time
+
+import fast_diff_match_patch as fdmp
+
+DEFAULT_ALPHABET = string.ascii_letters + string.digits + string.whitespace
+
+# speedtest1.txt: aaaabbccbcbbacc
+# speedtest2.txt: cbbccbccbbbcbac
+
+def gen_test_random(size1, size2, letters=DEFAULT_ALPHABET):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings are random."""
+    text1 = "".join(random.choices(letters, k=size1))
+    text2 = "".join(random.choices(letters, k=size2))
+    return text1, text2
+
+def gen_test_common_substring(size1, size2, common_len, letters=DEFAULT_ALPHABET):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings have a common SUBSTRING of length at least common_len. Here substring
+        means a continuous common sequence."""
+    assert(common_len <= size1 and common_len <= size2)
+    
+    common_text = "".join(random.choices(letters, k=common_len))
+
+    offset = random.randint(0, size1 - common_len)
+    text_before = "".join(random.choices(letters, k=offset))
+    text_after = "".join(random.choices(letters, k=size1-offset-common_len))
+    text1 = text_before + common_text + text_after
+
+    offset = random.randint(0, size2 - common_len)
+    text_before = "".join(random.choices(letters, k=offset))
+    text_after = "".join(random.choices(letters, k=size2-offset-common_len))
+    text2 = text_before + common_text + text_after
+
+    return text1, text2
+
+def gen_test_common_subsequence(size1, size2, common_len, letters=DEFAULT_ALPHABET):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings have a common SUBSEQUENCE of length at least common_len."""
+    assert(common_len <= size1 and common_len <= size2)
+    
+    common_text = "".join(random.choices(letters, k=common_len))
+
+    # Generate a text that has common_text as subsequence
+    # The builder lets us insert strings at any position in common_text
+    builder = [("", [])] + [(c, []) for c in common_text]
+    text = "".join(random.choices(letters, k=size1 - common_len))
+    positions = random.choices(range(common_len + 1), k=size1 - common_len)
+    for c, pos in zip(text, positions):
+        builder[pos][1].append(c)
+    # Merge the parts in the builder
+    text1 = "".join([part + "".join(suffix) for part, suffix in builder])
+
+    # Generate a text that has common_text as subsequence
+    # The builder lets us insert strings at any position in common_text
+    builder = [("", [])] + [(c, []) for c in common_text]
+    text = "".join(random.choices(letters, k=size2 - common_len))
+    positions = random.choices(range(common_len + 1), k=size2 - common_len)
+    for c, pos in zip(text, positions):
+        builder[pos][1].append(c)
+    # Merge the parts in the builder
+    text2 = "".join([part + "".join(suffix) for part, suffix in builder])
+
+    return text1, text2
+
+def gen_test_random_utf8(size1, size2):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings are random. The strings are UTF8."""
+    alphabet = "".join(chr(i) for i in range(0x110000))
+    return gen_test_random(size1, size2, alphabet)
+
+def gen_test_common_substring_utf8(size1, size2, common_len):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings have a common SUBSTRING of length at least common_len. Here substring
+        means a continuous common sequence. The strings are UTF8."""
+    alphabet = "".join(chr(i) for i in range(0x110000))
+    return gen_test_common_substring(size1, size2, common_len, alphabet)
+
+def gen_test_common_subsequence_utf8(size1, size2, common_len):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings have a common SUBSEQUENCE of length at least common_len.
+        The strings are UTF8."""
+    alphabet = "".join(chr(i) for i in range(0x110000))
+    return gen_test_common_subsequence(size1, size2, common_len, alphabet)
+
+
+def gen_test_binary_random(size1, size2, char1="a", char2="b"):
+    """Generates two strings of size1 and size2 and writes each of them in a file.
+        The strings have characters chosen from an alphabet of size 2.
+    """
+    assert len(char1) == 1
+    assert len(char2) == 1
+    letters = char1 + char2
+    return gen_test_random(size1, size2, letters)
+
+def benchmark_diff(text1, text2, timelimit):
+    start = time.time()
+    if timelimit:
+        diffs = fdmp.diff(text1, text2, timelimit=25, cleanup="No", counts_only=True)
+    else:
+        diffs = fdmp.diff(text1, text2, cleanup="No", counts_only=True)
+    count_old = sum(score for status, score in diffs if status != "=")
+    end = time.time()
+    delta_old = "{:.3f}".format(end - start)
+
+    start = time.time()
+    if timelimit:
+        count_new = fdmp.diff_count(text1, text2, timelimit=25)
+    else:
+        count_new = fdmp.diff_count(text1, text2)
+    end = time.time()
+    delta_new = "{:.3f}".format(end - start)
+
+    if float(delta_old) < 24 and float(delta_new) < 24:
+        if len(text1) + len(text2) < 3000:
+            assert count_old == count_new
+        else:
+            assert abs(count_old - count_new) / min(count_old, count_new) < 0.06
+
+    return {"count_old": count_old, "delta_old": delta_old, "count_new": count_new, "delta_new": delta_new}
+
+def benchmark_batch(size1, size2, timelimit=True):
+    batch_start = time.time()
+    print(f"Benchmark batch {(size1, size2)}")
+    min_size = min(size1, size2)
+    common_lens = [50, 100, min_size // 100, min_size // 10, min_size // 2, int(min_size * 0.99)]
+    common_lens = [length for length in common_lens if length <= min_size]
+
+    results = []
+
+    names = ("size1", "size2")
+    input = (size1, size2)
+    
+    """
+    texts = gen_test_random(*input)
+    result = benchmark_diff(*texts, timelimit)
+    result.update(dict(zip(names, input)))
+    result.update({"generator": "gen_test_random"})
+    results.append(result)
+    """
+
+    texts = gen_test_random_utf8(*input)
+    result = benchmark_diff(*texts, timelimit)
+    result.update(dict(zip(names, input)))
+    result.update({"generator": "gen_test_random_utf8"})
+    results.append(result)
+
+    texts = gen_test_binary_random(*input)
+    result = benchmark_diff(*texts, timelimit)
+    result.update(dict(zip(names, input)))
+    result.update({"generator": "gen_test_binary_random"})
+    results.append(result)
+
+    names = ("size1", "size2", "common_len")
+    for common_len in common_lens:
+        input = (size1, size2, common_len)
+
+        """
+        texts = gen_test_common_substring(*input)
+        result = benchmark_diff(*texts, timelimit)
+        result.update(dict(zip(names, input)))
+        result.update({"generator": "gen_test_common_substring"})
+        results.append(result)
+        """
+
+        texts =gen_test_common_subsequence(*input)
+        result = benchmark_diff(*texts, timelimit)
+        result.update(dict(zip(names, input)))
+        result.update({"generator": "gen_test_common_subsequence"})
+        results.append(result)
+
+        texts = gen_test_common_substring_utf8(*input)
+        result = benchmark_diff(*texts, timelimit)
+        result.update(dict(zip(names, input)))
+        result.update({"generator": "gen_test_common_substring_utf8"})
+        results.append(result)
+
+        texts = gen_test_common_subsequence_utf8(*input)
+        result = benchmark_diff(*texts, timelimit)
+        result.update(dict(zip(names, input)))
+        result.update({"generator": "gen_test_common_subequence_utf8"})
+        results.append(result)
+
+    batch_end = time.time()
+    print(f"Batch time: {batch_end - batch_start:.2f}")
+    return results
+
+def quick_test():
+    texts = gen_test_common_subsequence_utf8(12345, 15022, 1)
+    result = benchmark_diff(*texts, timelimit=True)
+    speedup = f"{float(result['delta_old']) / float(result['delta_new']):.2f}"
+    print(f"text1_len: 12345; text2_len: 15022; time_new: {result['delta_new']}; time_old: {result['delta_old']}; speedup: {speedup}")
+
+    texts = gen_test_common_subsequence_utf8(40345, 50022, 1)
+    result = benchmark_diff(*texts, timelimit=True)
+    speedup = f"{float(result['delta_old']) / float(result['delta_new']):.2f}"
+    print(f"text1_len: 40345; text2_len: 50022; time_new: {result['delta_new']}; time_old: {result['delta_old']}; speedup: {speedup}")
+
+    texts = gen_test_common_subsequence_utf8(12345, 15022, 5000)
+    result = benchmark_diff(*texts, timelimit=True)
+    speedup = f"{float(result['delta_old']) / float(result['delta_new']):.2f}"
+    print(f"text1_len: 12345; text2_len: 15022; time_new: {result['delta_new']}; time_old: {result['delta_old']}; speedup: {speedup}")
+
+    texts = gen_test_common_subsequence_utf8(60345, 70022, 30000)
+    result = benchmark_diff(*texts, timelimit=True)
+    speedup = f"{float(result['delta_old']) / float(result['delta_new']):.2f}"
+    print(f"text1_len: 60345; text2_len: 70022; time_new: {result['delta_new']}; time_old: {result['delta_old']}; speedup: {speedup}")
+
+    texts = gen_test_common_subsequence_utf8(60345, 70022, 55000)
+    result = benchmark_diff(*texts, timelimit=True)
+    speedup = f"{float(result['delta_old']) / float(result['delta_new']):.2f}"
+    print(f"text1_len: 60345; text2_len: 70022; time_new: {result['delta_new']}; time_old: {result['delta_old']}; speedup: {speedup}")
+
+def main():
+    print("Quick test:")
+    quick_test()
+    print("Quick test done.")
+
+    results = []
+    print("Start benchmark")
+    try:
+        #results += benchmark_batch(10**3, 2*10**6)
+        results += benchmark_batch(10, 10, timelimit=False)
+        results += benchmark_batch(10**6, 10**6)
+        results += benchmark_batch(10**2, 10**2, timelimit=False)
+        results += benchmark_batch(10**3, 10**3, timelimit=False)
+        results += benchmark_batch(10**5, 10**5)
+        results += benchmark_batch(10**3, 10**5)
+        results += benchmark_batch(10**4, 10**5)
+        results += benchmark_batch(10**4, 10**6)
+        results += benchmark_batch(12345, 54321)
+    except Exception:
+        print("Benchmark hasn't finished successfully.")
+
+    with open("results.json", "w") as f:
+        print("Storing results in results.json...")
+        f.write(json.dumps(results, sort_keys=True, indent=4))
+
+if __name__ == "__main__":
+    main()

--- a/gen_test.py
+++ b/gen_test.py
@@ -280,7 +280,7 @@ def do_main():
 
 def main():
     print("Quick test:")
-    #quick_test()
+    quick_test()
     print("Quick test done.")
 
     print("Start benchmark")

--- a/interface.cpp
+++ b/interface.cpp
@@ -252,7 +252,6 @@ diff_match_patch__diff_count__impl(PyObject *self, PyObject *args, PyObject *kwa
 {
     typename Shim::PY_ARG_TYPE a, b;
     float timelimit = 0.0;
-    int checklines = 1;
     char format_spec[64];
     int max_diff = -1;
 
@@ -260,14 +259,13 @@ diff_match_patch__diff_count__impl(PyObject *self, PyObject *args, PyObject *kwa
         strdup("left_document"),
         strdup("right_document"),
         strdup("timelimit"),
-        strdup("checklines"),
         strdup("max_diff"),
         NULL };
 
-    sprintf(format_spec, "%s%s|fbi", Shim::PyArgFormat, Shim::PyArgFormat);
+    sprintf(format_spec, "%s%s|fi", Shim::PyArgFormat, Shim::PyArgFormat);
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format_spec, kwlist,
                                      &a, &b,
-                                     &timelimit, &checklines, &max_diff))
+                                     &timelimit, &max_diff))
         return NULL;
     
     auto a_str = Shim::to_string(a),
@@ -294,8 +292,7 @@ diff_match_patch__diff_count__impl(PyObject *self, PyObject *args, PyObject *kwa
     Py_BEGIN_ALLOW_THREADS /* RELEASE THE GIL */
 
     dmp.Diff_Timeout = timelimit;
-    // ret = PyLong_FromLongLong(diff_count);
-    diff_count = dmp.diff_main_only_count(a_str, b_str, checklines, max_diff);
+    diff_count = dmp.diff_main_only_count(a_str, b_str, max_diff);
 
     Py_END_ALLOW_THREADS /* ACQUIRE THE GIL */
 
@@ -402,7 +399,7 @@ static PyMethodDef MyMethods[] = {
     {"diff", (PyCFunction)diff_match_patch__diff, METH_VARARGS|METH_KEYWORDS,
     "Compute the difference between two strings or bytes-like objects (Unicode and str's in Python 2). Returns a list of tuples (OP, LEN)."},
     {"diff_count", (PyCFunction)diff_match_patch__diff_count, METH_VARARGS|METH_KEYWORDS,
-    "Compute the difference between two strings or bytes-like objects (Unicode and str's in Python 2). Returns a list of tuples (OP, LEN)."},
+    "Compute the difference between two strings or bytes-like objects (Unicode and str's in Python 2). Returns the diff count measured in characters."},
     {"match_main", (PyCFunction)diff_match_patch__match, METH_VARARGS|METH_KEYWORDS,
     "Locate the best instance of 'pattern' in 'text' near 'loc'. Returns -1 if no match found."},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/process_results.py
+++ b/process_results.py
@@ -1,0 +1,64 @@
+import json
+from collections import defaultdict
+from statistics import mean, stdev
+
+RESULTS_FILE = "results.json"
+EXPECTED_KEYS = {"size1", "size2", "common_len", "generator", "delta_old", "delta_new", "count_old", "count_new"}
+TIMEOUT_LIMIT = 25
+
+
+def process(data):
+    for test in data:
+        keys = set(test.keys())
+        if not keys.issubset(EXPECTED_KEYS):
+            print(f"Unwanted data format: {test}")
+            return
+
+        
+    timeout_old = [1 for test in data if float(test['delta_old']) >= TIMEOUT_LIMIT]
+    timeout_new = [1 for test in data if float(test['delta_new']) >= TIMEOUT_LIMIT]
+
+    print(f"{len(timeout_old)}/{len(data)} tests timed out with the old algorithm.")
+    print(f"{len(timeout_new)}/{len(data)} tests timed out with the new algorithm.")
+
+    real_data = [test for test in data if float(test['delta_new']) < TIMEOUT_LIMIT or float(test['delta_old']) < TIMEOUT_LIMIT]
+    print(f"In {len(data) - len(real_data)}/{len(data)} tests, both algorithms timed out. Removing them...")
+
+    old_len = len(real_data)
+    real_data = [test for test in real_data if float(test['delta_new']) >= 1 or float(test['delta_old']) >= 1]
+    print(f"In {old_len - len(real_data)}/{old_len} tests, the times were under 1 second. Removing them...")
+
+    faster = [1 for test in real_data if float(test['delta_new']) < float(test['delta_old']) or float(test['delta_new']) < 0.01]
+    slower = [test for test in real_data if not(float(test['delta_new']) < float(test['delta_old']) or float(test['delta_new']) < 0.01)]
+    speedup = [float(test['delta_old']) / float(test['delta_new']) if float(test['delta_new']) > 0.001 else 1 for test in real_data]
+
+    print(f"In {len(faster)}/{len(real_data)} tests, the new algorithm is faster or the same.")
+    print(f"Tests where the new algorithm is slower: {slower}")
+
+    print(f"Speedup mean: {mean(speedup):.3f}")
+    print(f"Speedup stdev: {stdev(speedup):.3f}")
+
+    generator_groups = defaultdict(list)
+    for test in real_data:
+        generator_groups[test["generator"]].append(test)
+
+    print("")
+    for generator, gen_data in generator_groups.items():
+        speedup = [float(test['delta_old']) / float(test['delta_new']) if float(test["delta_new"]) > 0.02 else 1 for test in gen_data]
+        print(f"{len(gen_data)} tests for {generator}")
+        print(f"For {generator}, speedup mean: {mean(speedup):.3f}")
+        print(f"For {generator}, speedup stdev: {stdev(speedup):.3f}\n")
+
+
+    for test in real_data:
+        test["complexity"] = test["count_new"] * max(test["size1"], test["size2"])
+        test["new_complexity"] = test["count_new"] * test["count_new"]
+
+
+def main():
+    with open(RESULTS_FILE, "r", encoding="utf8") as f:
+        data = json.load(f)
+
+    process(data)
+
+main()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -20,6 +20,13 @@ class DiffTests(unittest.TestCase):
             checklines=False)
         self.assertEqual(actual, expected_counts_only)
 
+    def assertDiffCount(self, text1, text2, max_diff, expected_count):
+        actual = fast_diff_match_patch.diff_count(
+            text1, text2,
+            timelimit=15,
+            max_diff=max_diff)
+        self.assertEqual(actual, expected_count)
+
     def test_string(self):
         self.assertDiff(
             '',
@@ -50,6 +57,41 @@ class DiffTests(unittest.TestCase):
                 ('+', 16),
                 ('=', 7),
             ]
+        )
+
+        self.assertDiffCount(
+            '',
+            '',
+            0,
+            0,
+        )
+
+        self.assertDiffCount(
+            'this is a test',
+            'this is a test',
+            1,
+            0,
+        )
+
+        self.assertDiffCount(
+            'this is a test',
+            'this program is not \u2192 a test',
+            15,
+            14,
+        )
+
+        self.assertDiffCount(
+            'this is a test',
+            'this program is not \u2192 a test',
+            10,
+            14,
+        )
+
+        self.assertDiffCount(
+            'this is a tesa',
+            'this program is not \u2192 a test',
+            10,
+            32,
         )
 
     def test_binary(self):


### PR DESCRIPTION
## Installation
We recommend running these commands in a python virtual environment.
```sh
python3 -m pip uninstall fast_diff_match_patch
git clone https://github.com/razvan-pricop-ptt/fast_diff_match_patch
cd fast_diff_match_patch/
git submodule set-url -- diff-match-patch-cpp-stl https://github.com/razvan-pricop-ptt/diff-match-patch-cpp-stl # This won't be needed after the merge into pentest-tools/diff-match-patch-cpp-stl
git submodule update --init --remote diff-match-patch-cpp-stl
rm -rf build # Only needed if you've built the project before, in this directory
python3 setup.py build
python3 setup.py install
```

## Benchmark
For quick testing, run `gen_test.py` and wait for the message "Quick test done". It should take at most 2 minutes. For the whole benchmark, let the script run until the end. It takes about one hour.
```
 time python3 gen_test.py
```
Example results:
```
Quick test:
text1_len: 12345; text2_len: 15022; time_new: 0.658; time_old: 1.961; speedup: 2.98
text1_len: 40345; text2_len: 50022; time_new: 7.501; time_old: 22.325; speedup: 2.98
text1_len: 12345; text2_len: 15022; time_new: 0.425; time_old: 1.460; speedup: 3.44
text1_len: 60345; text2_len: 70022; time_new: 8.395; time_old: 23.400; speedup: 2.79
text1_len: 60345; text2_len: 70022; time_new: 0.752; time_old: 1.593; speedup: 2.12
Quick test done.
Start benchmark
Benchmark batch (10, 10)
Batch time: 1.96
Benchmark batch (1000000, 1000000)
Batch time: 906.21
Benchmark batch (100, 100)
Batch time: 2.90
Benchmark batch (1000, 1000)
Batch time: 3.07
Benchmark batch (100000, 100000)
Batch time: 803.19
Benchmark batch (1000, 100000)
Batch time: 26.77
Benchmark batch (10000, 100000)
Batch time: 234.99
Benchmark batch (10000, 1000000)
Batch time: 845.58
Benchmark batch (12345, 54321)
Batch time: 164.06
Storing results in results.json...
```

After processing the results:
```
51/174 tests timed out with the old algorithm.
41/174 tests timed out with the new algorithm.
In 41/174 tests, both algorithms timed out. Removing them...
In 66/133 tests, the times were under 1 second. Removing them...
In 66/67 tests, the new algorithm is faster or the same.
Tests where the new algorithm is slower: [{'common_len': 990000, 'count_new': 19998, 'count_old': 19998, 'delta_new': '2.486', 'delta_old': '1.526', 'generator': 'gen_test_common_subsequence', 'size1': 1000000, 'size2': 1000000}]
Speedup mean: 3.722
Speedup stdev: 1.787

20 tests for gen_test_common_subsequence
For gen_test_common_subsequence, speedup mean: 4.303
For gen_test_common_subsequence, speedup stdev: 1.362

21 tests for gen_test_common_subequence_utf8
For gen_test_common_subequence_utf8, speedup mean: 3.219
For gen_test_common_subequence_utf8, speedup stdev: 1.205

4 tests for gen_test_binary_random
For gen_test_binary_random, speedup mean: 6.993
For gen_test_binary_random, speedup stdev: 4.126

19 tests for gen_test_common_substring_utf8
For gen_test_common_substring_utf8, speedup mean: 3.091
For gen_test_common_substring_utf8, speedup stdev: 1.323

3 tests for gen_test_random_utf8
For gen_test_random_utf8, speedup mean: 2.994
For gen_test_random_utf8, speedup stdev: 0.077
```

Explanation of the generators:
- gen_test_random_utf8 - test in which the 2 texts are randomly generated and can take any utf8 values
- gen_test_common_substring_utf8 - test in which the 2 texts are utf8 random, but have a common substring
- gen_test_binary_random - test in which the 2 texts are random and made only of characters 'a' and 'b'
- gen_test_common_subequence_utf8 - test in which the 2 texts are utf8 random, but have a common subsequence
- gen_test_common_subsequence - test in which the 2 texts are random, but characters are ASCII

## Conclusion

From the custom benchmark, we can draw 2 important conclusions:
- In all cases, the new algorithm is at least 2 times faster
- When the strings are mostly different, the speedup is 3